### PR TITLE
Deal with input files without subject; Correct the cladogram plot

### DIFF
--- a/format_input.py
+++ b/format_input.py
@@ -450,7 +450,7 @@ if  __name__ == '__main__':
 
     cls['subclass'] = rename_same_subcl(cls['class'],cls['subclass'])
 #   if 'subclass' in cls.keys(): cls = group_small_subclasses(cls,params['subcl_min_card'])
-    class_sl,subclass_sl,class_hierarchy = get_class_slices(list(zip(cls['class'], cls['subclass'], cls['subject'])))
+    class_sl,subclass_sl,class_hierarchy = get_class_slices(list(zip(*cls.values())))
 
     feats = dict([(d[0],d[1:]) for d in data])
 

--- a/plot_cladogram.py
+++ b/plot_cladogram.py
@@ -314,6 +314,7 @@ def draw_tree(out_file,tree,params):
 
     h, l = ax.get_legend_handles_labels()
     if len(l) > 0:
+        # Each column allows at most 35 species (rows)
         ncol = len(l)//35+1
         leg = ax.legend(bbox_to_anchor=(1.02, 1), frameon=False, loc=2, borderaxespad=0.,
                 prop={'size':params['label_font_size']},ncol=ncol)
@@ -333,7 +334,7 @@ def draw_tree(out_file,tree,params):
         if l2 != None:
             for o in l2.findobj(get_col_attr):
                     o.set_color(params['fore_color'])
-
+    # add bbox to deal with legnd overflow
     plt.savefig(out_file,format=params['format'],facecolor=params['back_color'],edgecolor=params['fore_color'],dpi=params['dpi'], bbox_inches='tight')
     plt.close()    
 

--- a/plot_cladogram.py
+++ b/plot_cladogram.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os,sys,matplotlib,argparse,string
+# from io import StringIO
 matplotlib.use('Agg')
 from pylab import *
 from lefse import *
@@ -98,7 +99,8 @@ def get_all_nodes(father):
 
 def read_data(input_file,params):
     with open(input_file, 'r') as inp:
-        if params['sub_clade'] == "": rows = [line.strip().split()[:-1] for line in inp.readlines() if params['max_lev'] < 1 or line.split()[0].count(".") < params['max_lev']]
+        if params['sub_clade'] == "": 
+            rows = [line.strip().split()[:-1] for line in inp.readlines() if params['max_lev'] < 1 or line.split()[0].count(".") < params['max_lev']]
         else: rows = [line.split(params['sub_clade']+".")[1].strip().split()[:-1] for line in inp.readlines() if ( params['max_lev'] < 1 or line.split()[0].count(".") < params['max_lev'] ) and line.startswith(params['sub_clade']+".")]
     all_names = [lin[0] for lin in rows]
     to_add = []
@@ -229,8 +231,8 @@ def plot_lines(father,params,depth,ax,xf):
     return x,r 
 
 def uniqueid():
-    for l in string.lowercase: yield l
-    for l in string.lowercase:
+    for l in string.ascii_lowercase: yield l
+    for l in string.ascii_lowercase:
         for i in range(10):
             yield l+str(i)
     i = 0
@@ -245,12 +247,12 @@ def plot_names(father,params,depth,ax,u_i,seps):
         if father.prev_leaf == -1 or father.next_leaf == -1:
             fr_0, fr_1 = father.pos[0], father.pos[0]
         else: fr_0, fr_1 =  (father.pos[0]+father.prev_leaf.pos[0])*0.5, (father.pos[0]+father.next_leaf.pos[0])*0.5
-        for i,child in enumerate(children):
-                fr,to = plot_names(child,params,depth,ax,u_i,seps)
-                if i == 0: fr_0 = fr
+    for i,child in enumerate(children):
+        fr,to = plot_names(child,params,depth,ax,u_i,seps)
+        if i == 0: fr_0 = fr
         fr_1 = to 
-        if father.get_color() != 'y' and params['labeled_start_lev'] < l <= params['labeled_stop_lev']+1:
-                col = father.get_color()
+    if father.get_color() != 'y' and params['labeled_start_lev'] < l <= params['labeled_stop_lev']+1:
+        col = father.get_color()
         dd = params['labeled_stop_lev'] - params['labeled_start_lev'] + 1 
         de = depth - 1
         dim = 1.0/float(de)
@@ -273,7 +275,7 @@ def plot_names(father,params,depth,ax,u_i,seps):
                 if col not in colors: col = params['fore_color']
                 else: col = dark_colors[colors.index(col)%len(dark_colors)]
             ax.text((fr_0+fr_1)*0.5, clto+float(l-1)/float(de)-dim*perc_ext/2.0, txt, size = params['label_font_size'], rotation=des, ha ="center", va="center", color=col)    
-        return fr_0, fr_1
+    return fr_0, fr_1
 
 def draw_tree(out_file,tree,params):
     plt_size = 7
@@ -304,7 +306,6 @@ def draw_tree(out_file,tree,params):
     plot_lines(tree['root'],params,depth,ax,0)
     plot_points(tree['root'],params,pt_scale,ax)
     plot_names(tree['root'],params,depth,ax,uniqueid(),seps)
-
     r = np.arange(0, 3.0, 0.01)
     theta = 2*np.pi*r
     
@@ -313,11 +314,13 @@ def draw_tree(out_file,tree,params):
 
     h, l = ax.get_legend_handles_labels()
     if len(l) > 0:
-        leg = ax.legend(bbox_to_anchor=(1.05, 1), frameon=False, loc=2, borderaxespad=0.,prop={'size':params['label_font_size']})
+        ncol = len(l)//35+1
+        leg = ax.legend(bbox_to_anchor=(1.02, 1), frameon=False, loc=2, borderaxespad=0.,
+                prop={'size':params['label_font_size']},ncol=ncol)
         if leg != None:
             gca().add_artist(leg)
             for o in leg.findobj(get_col_attr):
-                            o.set_color(params['fore_color'])
+                o.set_color(params['fore_color'])
     
     cll = sorted(tree['classes']) if params['all_feats'] == "" else sorted(params['all_feats'].split(":"))
     nll = [ax.bar(0.0, 0.0, width = 0.0, bottom = 0.0, color=colors[i%len(colors)], label=c) for i,c in enumerate(cll) if c in tree['classes']]
@@ -331,7 +334,7 @@ def draw_tree(out_file,tree,params):
             for o in l2.findobj(get_col_attr):
                     o.set_color(params['fore_color'])
 
-    plt.savefig(out_file,format=params['format'],facecolor=params['back_color'],edgecolor=params['fore_color'],dpi=params['dpi'])
+    plt.savefig(out_file,format=params['format'],facecolor=params['back_color'],edgecolor=params['fore_color'],dpi=params['dpi'], bbox_inches='tight')
     plt.close()    
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dear maintainers,

When using the current `main` branch of `lefse`, I have met some problems and did some changes. Would you like to check if these could be merged to the `main` branch?

1. Modify codes for dealing with the input matrix without the `subject` row in `format_input.py`.
2. The `plot_names` of `plot_cladogram.py` in the current `main` branch of `lefse` has wrong indentations and could not generate legends and shaded branches.
    1. The indentation is corrected.
    2. `string.ascii_lowercase` is used for python3 compatibility.
    3. `ncol` and `bbox_inches` parts are added for getting better legend output (mainly to avoid the legend overflow problem).

Best,

Chen Tong