### PR TITLE
fix: preserve taxonomic separators in feature names

### DIFF
--- a/lefse/lefse_format_input.py
+++ b/lefse/lefse_format_input.py
@@ -268,7 +268,7 @@ def modify_feature_names(fn):
         ret = [re.sub(v,"",f) for f in ret]
 
     for v in ["/",r'\(',r'\)',r'-',r'\+',r'=',r'{',r'}',r'\[',r'\]',
-              r',',r'\.',r';',r':',r'\?',r'\<',r'\>',r'\.',r'\,']:
+              r',',r';',r':',r'\?',r'\<',r'\>',r'\,']:
         ret = [re.sub(v,"_",f) for f in ret]
 
     for v in ["\|"]:


### PR DESCRIPTION
- Remove r'\.' from special character replacement to preserve dot separators
- Fixes inconsistent behavior between | and . input separators
- Ensures proper taxonomic hierarchy recognition in all cases